### PR TITLE
build.gradle: change archiveFileName

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'TrAcker.jar'
 }
 
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
Change archiveFileName so that "TrAcker.jar" is written as the jar file name instead of addressbook.jar

Also uncapitalised event names in resources/images.