### PR TITLE
Fix note command handling bug

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -600,39 +600,39 @@ By double-clicking on events, the notes section will appear
    <tr>
       <td><strong>Add Note To Event</strong>
       </td>
-      <td><code>addNote note -content hello world -type tutorial -name 2</code>
+      <td><code>addNote note content/[CONTENT] type/[TYPE] name/[NAME]</code>
       </td>
       <td>
          <ul>
-            <li><code>addNote note -content rmb to bring along apple pencil\n -type Tutorial -name 2</code>
-            <li><code>addNote note -content grade student labs timely\n -type Lab -name 2</code></li>
-            <li><code>addNote note -content solve this student's query via email\n -type Recur -name 2</code></li>
+            <li><code>addNote note content/rmb to bring along apple pencil\n type/Tutorial name/2</code>
+            <li><code>addNote note content/grade student labs timely\n type/Lab name/2</code></li>
+            <li><code>addNote note content/solve this student's query via email\n type/Recur name/2</code></li>
          </ul>
       </td>
    </tr>
    <tr>
       <td><strong>Delete Note From Event</strong>
       </td>
-      <td><code>deleteNote [TYPE] [NAME or INDEX] [NOTE_INDEX]</code>
+      <td><code>deleteNote type/[EVENT_TYPE] name/[EVENT_NAME] index/[NOTE_INDEX]</code>
       </td>
       <td>
          <ul>
-            <li><code>deleteNote -type Tutorial -name 2 -index 3</code>
-            <li><code>deleteNote -type Lab -name 2 -index 1</code></li>
-            <li><code>deleteNote -type Recur -name 2 -index 0</code></li>
+            <li><code>deleteNote type/Tutorial name/2 index/3</code>
+            <li><code>deleteNote type/Lab name/2 index/1</code></li>
+            <li><code>deleteNote type/Recur name/2 index/0</code></li>
          </ul>
       </td>
    </tr>
    <tr>
       <td><strong>Edit Note In Event</strong>
       </td>
-      <td><code>editNote [TYPE] [NAME or INDEX] [NOTE_INDEX] [NEW_CONTENT]</code>
+      <td><code>editNote type/[EVENT_TYPE] name/[EVENT_NAME] index/[NOTE_INDEX] content/[NEW_CONTENT]</code>
       </td>
       <td>
          <ul>
-            <li><code>editNote -content rmb to bring along apple pencil\n -type Tutorial -name 2 -index 3</code>
-            <li><code>editNote -content grade student labs timely\n -type Lab -name 2 -index 1</code></li>
-            <li><code>editNote -content solve this student's query via email\n -type Recur -name 2 -index 0</code></li>
+            <li><code>editNote content/rmb to bring along apple pencil\n type/Tutorial name/2 index/3</code>
+            <li><code>editNote content/grade student labs timely\n type/Lab name/2 index/1</code></li>
+            <li><code>editNote content/solve this student's query via email\n type/Recur name/2 index/0</code></li>
          </ul>
       </td>
    </tr>

--- a/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
@@ -12,10 +12,10 @@ import seedu.address.model.event.Note;
 public class AddNoteToEventCommand extends Command {
     public static final String COMMAND_WORD = "addNote";
     public static final String MESSAGE_SUCCESS = "Note specified has been successfully added";
-    public static final String MESSAGE_USAGE = "addNote note content/ add-your-note-here name/ name-of-event "
-            + "type/ type-of-event";
-    public static final String MESSAGE_EXAMPLE = "addNote note content/ this is a new note name/ dijkstraReview "
-            + "type/ Tutorial";
+    public static final String MESSAGE_USAGE = "addNote note content/add-your-note-here name/name-of-event "
+            + "type/type-of-event";
+    public static final String MESSAGE_EXAMPLE = "addNote note content/this is a new note name/dijkstraReview "
+            + "type/Tutorial";
 
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
             + " cannot be recognized!";

--- a/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
@@ -18,7 +18,7 @@ public class AddNoteToEventCommand extends Command {
             + "type/Tutorial";
 
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
-            + " cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";
+            + " cannot be recognized! Please enter type such as Tutorial, Lab, or Consultation";
     public static final String MESSAGE_EVENT_NAME_NOT_FOUND = "The event name %1$s is not found in the list!";
 
     public static final String TUTORIAL_STRING = "Tutorial";

--- a/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.event.Note;
 public class AddNoteToEventCommand extends Command {
     public static final String COMMAND_WORD = "addNote";
     public static final String MESSAGE_SUCCESS = "Note specified has been successfully added";
-    public static final String MESSAGE_USAGE = "addNote-content add-your-note-here -name name-of-event "
+    public static final String MESSAGE_USAGE = "addNote note -content add-your-note-here -name name-of-event "
             + "-type type-of-event";
     public static final String MESSAGE_EXAMPLE = "addNote note -content this is a new note -name dijkstraReview "
             + "-type Tutorial";

--- a/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.event.Note;
  */
 public class AddNoteToEventCommand extends Command {
     public static final String COMMAND_WORD = "addNote";
-    public static final String MESSAGE_SUCCESS = "Note specified has been successfully added";
+    public static final String MESSAGE_SUCCESS = "A new note has been successfully added";
     public static final String MESSAGE_USAGE = "addNote note content/add-your-note-here name/name-of-event "
             + "type/type-of-event";
     public static final String MESSAGE_EXAMPLE = "addNote note content/this is a new note name/dijkstraReview "

--- a/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
@@ -12,13 +12,15 @@ import seedu.address.model.event.Note;
 public class AddNoteToEventCommand extends Command {
     public static final String COMMAND_WORD = "addNote";
     public static final String MESSAGE_SUCCESS = "Note specified has been successfully added";
-    public static final String MESSAGE_USAGE = "addNote note -content add-your-note-here -name name-of-event "
-            + "-type type-of-event";
-    public static final String MESSAGE_EXAMPLE = "addNote note -content this is a new note -name dijkstraReview "
-            + "-type Tutorial";
+    public static final String MESSAGE_USAGE = "addNote note content/ add-your-note-here name/ name-of-event "
+            + "type/ type-of-event";
+    public static final String MESSAGE_EXAMPLE = "addNote note content/ this is a new note name/ dijkstraReview "
+            + "type/ Tutorial";
 
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
             + " cannot be recognized!";
+    public static final String MESSAGE_EVENT_NAME_NOT_FOUND = "The event name %1$s is not found in the list!";
+
     public static final String TUTORIAL_STRING = "Tutorial";
     public static final String LAB_STRING = "Lab";
     public static final String CONSULTATION_STRING = "Consultation";
@@ -44,20 +46,22 @@ public class AddNoteToEventCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        boolean addResult;
 
-        switch (eventType) {
-        case TUTORIAL_STRING:
-            model.addNoteToTutorial(toAdd, eventName);
-            break;
-        case LAB_STRING:
-            model.addNoteToLab(toAdd, this.eventName);
-            break;
-        case CONSULTATION_STRING:
-            model.addNoteToConsultation(toAdd, this.eventName);
-            break;
-        default:
+        if (eventType.toLowerCase().contains(TUTORIAL_STRING.toLowerCase())) {
+            addResult = model.addNoteToTutorial(toAdd, eventName);
+        } else if (eventType.toLowerCase().contains(LAB_STRING.toLowerCase())) {
+            addResult = model.addNoteToLab(toAdd, this.eventName);
+        } else if (eventType.toLowerCase().contains(CONSULTATION_STRING.toLowerCase())) {
+            addResult = model.addNoteToConsultation(toAdd, this.eventName);
+        } else {
             throw new CommandException(MESSAGE_EVENT_TYPE_NOT_RECOGNIZED);
         }
+
+        if (!(addResult)) {
+            throw new CommandException(String.format(MESSAGE_EVENT_NAME_NOT_FOUND, eventName));
+        }
+
         return new CommandResult(String.format(MESSAGE_SUCCESS), false, false, false, true);
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddNoteToEventCommand.java
@@ -18,7 +18,7 @@ public class AddNoteToEventCommand extends Command {
             + "type/Tutorial";
 
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
-            + " cannot be recognized!";
+            + " cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";
     public static final String MESSAGE_EVENT_NAME_NOT_FOUND = "The event name %1$s is not found in the list!";
 
     public static final String TUTORIAL_STRING = "Tutorial";

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -17,7 +17,9 @@ public class DeleteNoteCommand extends Command {
     public static final String MESSAGE_EXAMPLE = "deleteNote -index 1 -name t1 -type Tutorial";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
             + "cannot be recognized!";
-    public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Deleted note: %1$s";
+    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your specified event %2$s!";
+
+    public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Deleted note indexed %1$s from event %2$s";
 
     public static final String TUTORIAL_STRING = "Tutorial";
     public static final String LAB_STRING = "Lab";
@@ -39,22 +41,22 @@ public class DeleteNoteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
-        switch (eventType) {
-        case TUTORIAL_STRING:
-            model.removeNoteFromTutorial(targetIndex, eventName);
-            break;
-        case LAB_STRING:
-            model.removeNoteFromLab(targetIndex, this.eventName);
-            break;
-        case CONSULTATION_STRING:
-            model.removeNoteFromConsultation(targetIndex, this.eventName);
-            break;
-        default:
+        boolean rmResult;
+        if (eventType.toLowerCase().contains(TUTORIAL_STRING.toLowerCase())) {
+            rmResult = model.removeNoteFromTutorial(targetIndex, eventName);
+        } else if (eventType.toLowerCase().contains(LAB_STRING.toLowerCase())) {
+            rmResult = model.removeNoteFromLab(targetIndex, this.eventName);
+        } else if (eventType.toLowerCase().contains(CONSULTATION_STRING.toLowerCase())) {
+            rmResult = model.removeNoteFromConsultation(targetIndex, this.eventName);
+        } else {
             throw new CommandException(MESSAGE_EVENT_TYPE_NOT_RECOGNIZED);
         }
-        return new CommandResult(String.format(MESSAGE_DELETE_NOTE_SUCCESS, targetIndex), false, false,
-                false, true);
+        if (!(rmResult)) {
+            throw new CommandException(String.format(MESSAGE_NOTE_INDEX_NOT_FOUND, targetIndex.getOneBased(), eventName));
+        } else {
+            return new CommandResult(String.format(MESSAGE_DELETE_NOTE_SUCCESS, targetIndex.getOneBased(), eventName), false, false,
+                    false, true);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -12,9 +12,9 @@ import seedu.address.model.Model;
 public class DeleteNoteCommand extends Command {
     public static final String COMMAND_WORD = "deleteNote";
 
-    public static final String MESSAGE_USAGE = "Delete syntax: deleteNote index/ INDEX (must be a positive integer) "
-            + "name/ name-of-event type/ type-of-event";
-    public static final String MESSAGE_EXAMPLE = "deleteNote index/ 1 name/ t1 type/ Tutorial";
+    public static final String MESSAGE_USAGE = "Delete syntax: deleteNote index/INDEX (must be a positive integer) "
+            + "name/name-of-event type/type-of-event";
+    public static final String MESSAGE_EXAMPLE = "deleteNote index/1 name/t1 type/Tutorial";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
             + "cannot be recognized!";
     public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your specified event %2$s!";

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -17,7 +17,8 @@ public class DeleteNoteCommand extends Command {
     public static final String MESSAGE_EXAMPLE = "deleteNote index/1 name/t1 type/Tutorial";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
             + "cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";
-    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your specified event %2$s!";
+    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your " +
+            "specified event %2$s!";
 
     public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Deleted note indexed %1$s from event %2$s";
 
@@ -52,9 +53,11 @@ public class DeleteNoteCommand extends Command {
             throw new CommandException(MESSAGE_EVENT_TYPE_NOT_RECOGNIZED);
         }
         if (!(rmResult)) {
-            throw new CommandException(String.format(MESSAGE_NOTE_INDEX_NOT_FOUND, targetIndex.getOneBased(), eventName));
+            throw new CommandException(String.format(MESSAGE_NOTE_INDEX_NOT_FOUND, targetIndex.getOneBased(),
+                    eventName));
         } else {
-            return new CommandResult(String.format(MESSAGE_DELETE_NOTE_SUCCESS, targetIndex.getOneBased(), eventName), false, false,
+            return new CommandResult(String.format(MESSAGE_DELETE_NOTE_SUCCESS, targetIndex.getOneBased(),
+                    eventName), false, false,
                     false, true);
         }
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -16,7 +16,7 @@ public class DeleteNoteCommand extends Command {
             + "name/name-of-event type/type-of-event";
     public static final String MESSAGE_EXAMPLE = "deleteNote index/1 name/t1 type/Tutorial";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
-            + "cannot be recognized!";
+            + "cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";
     public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your specified event %2$s!";
 
     public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Deleted note indexed %1$s from event %2$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -16,10 +16,8 @@ public class DeleteNoteCommand extends Command {
             + "name/name-of-event type/type-of-event";
     public static final String MESSAGE_EXAMPLE = "deleteNote index/1 name/t1 type/Tutorial";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
-            + "cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";
-    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your "
-            + "specified event %2$s!";
-
+            + "cannot be recognized! Please enter type such as Tutorial, Lab, or Consultation";
+    public static final String MESSAGE_NOTE_NOT_FOUND = "The event %2$s itself or its note indexed %1$s is not found!";
     public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Deleted note indexed %1$s from event %2$s";
 
     public static final String TUTORIAL_STRING = "Tutorial";
@@ -53,7 +51,7 @@ public class DeleteNoteCommand extends Command {
             throw new CommandException(MESSAGE_EVENT_TYPE_NOT_RECOGNIZED);
         }
         if (!(rmResult)) {
-            throw new CommandException(String.format(MESSAGE_NOTE_INDEX_NOT_FOUND, targetIndex.getOneBased(),
+            throw new CommandException(String.format(MESSAGE_NOTE_NOT_FOUND, targetIndex.getOneBased(),
                     eventName));
         } else {
             return new CommandResult(String.format(MESSAGE_DELETE_NOTE_SUCCESS, targetIndex.getOneBased(),

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -12,9 +12,9 @@ import seedu.address.model.Model;
 public class DeleteNoteCommand extends Command {
     public static final String COMMAND_WORD = "deleteNote";
 
-    public static final String MESSAGE_USAGE = "Delete syntax: deleteNote -index INDEX (must be a positive integer) "
-            + "-name name-of-event -type type-of-event";
-    public static final String MESSAGE_EXAMPLE = "deleteNote -index 1 -name t1 -type Tutorial";
+    public static final String MESSAGE_USAGE = "Delete syntax: deleteNote index/ INDEX (must be a positive integer) "
+            + "name/ name-of-event type/ type-of-event";
+    public static final String MESSAGE_EXAMPLE = "deleteNote index/ 1 name/ t1 type/ Tutorial";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
             + "cannot be recognized!";
     public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your specified event %2$s!";

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -15,7 +15,7 @@ public class DeleteNoteCommand extends Command {
     public static final String MESSAGE_USAGE = "Delete syntax: deleteNote index/INDEX (must be a positive integer) "
             + "name/name-of-event type/type-of-event";
     public static final String MESSAGE_EXAMPLE = "deleteNote index/1 name/t1 type/Tutorial";
-    public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
+    public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered "
             + "cannot be recognized! Please enter type such as Tutorial, Lab, or Consultation";
     public static final String MESSAGE_NOTE_NOT_FOUND = "The event %2$s itself or its note indexed %1$s is not found!";
     public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Deleted note indexed %1$s from event %2$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteNoteCommand.java
@@ -17,8 +17,8 @@ public class DeleteNoteCommand extends Command {
     public static final String MESSAGE_EXAMPLE = "deleteNote index/1 name/t1 type/Tutorial";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
             + "cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";
-    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your " +
-            "specified event %2$s!";
+    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your "
+            + "specified event %2$s!";
 
     public static final String MESSAGE_DELETE_NOTE_SUCCESS = "Deleted note indexed %1$s from event %2$s";
 

--- a/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
@@ -17,7 +17,8 @@ public class EditNoteCommand extends Command {
             + " content/updated-note name/name-of-event type/type-of-event";
     public static final String MESSAGE_EXAMPLE = "editNote index/1 content/this is my updated notes name/"
             + "tutorial 1 type/Tutorial";
-    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your specified event %2$s!";
+    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your " +
+            "specified event %2$s!";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
             + " cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";
     public static final String MESSAGE_EDIT_NOTE_SUCCESS = "Edited note: %1$s";
@@ -55,7 +56,8 @@ public class EditNoteCommand extends Command {
             throw new CommandException(MESSAGE_EVENT_TYPE_NOT_RECOGNIZED);
         }
         if (!(editResult)) {
-            throw new CommandException(String.format(MESSAGE_NOTE_INDEX_NOT_FOUND, targetIndex.getOneBased(), eventName));
+            throw new CommandException(String.format(MESSAGE_NOTE_INDEX_NOT_FOUND, targetIndex.getOneBased(),
+                    eventName));
         } else {
             return new CommandResult(String.format(MESSAGE_EDIT_NOTE_SUCCESS, note), false, false,
                     false, true);

--- a/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
@@ -17,8 +17,9 @@ public class EditNoteCommand extends Command {
             + " -content updated-note -name name-of-event -type type-of-event";
     public static final String MESSAGE_EXAMPLE = "editNote -index 1 -content this is my updated notes -name "
             + "tutorial 1 -type Tutorial";
+    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your specified event %2$s!";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
-            + " cannot be recognized!";
+            + " cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";
     public static final String MESSAGE_EDIT_NOTE_SUCCESS = "Edited note: %1$s";
 
     public static final String TUTORIAL_STRING = "Tutorial";
@@ -43,22 +44,22 @@ public class EditNoteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
-        switch (eventType) {
-        case TUTORIAL_STRING:
-            model.editNoteFromTutorial(targetIndex, note, eventName);
-            break;
-        case LAB_STRING:
-            model.editNoteFromLab(targetIndex, note, eventName);
-            break;
-        case CONSULTATION_STRING:
-            model.editNoteFromConsultation(targetIndex, note, eventName);
-            break;
-        default:
+        boolean editResult;
+        if (eventType.toLowerCase().contains(TUTORIAL_STRING.toLowerCase())) {
+            editResult = model.editNoteFromTutorial(targetIndex, note, eventName);
+        } else if (eventType.toLowerCase().contains(LAB_STRING.toLowerCase())) {
+            editResult = model.editNoteFromLab(targetIndex, note, eventName);
+        } else if (eventType.toLowerCase().contains(CONSULTATION_STRING.toLowerCase())) {
+            editResult = model.editNoteFromConsultation(targetIndex, note, eventName);
+        } else {
             throw new CommandException(MESSAGE_EVENT_TYPE_NOT_RECOGNIZED);
         }
-        return new CommandResult(String.format(MESSAGE_EDIT_NOTE_SUCCESS, note), false, false,
-                false, true);
+        if (!(editResult)) {
+            throw new CommandException(String.format(MESSAGE_NOTE_INDEX_NOT_FOUND, targetIndex.getOneBased(), eventName));
+        } else {
+            return new CommandResult(String.format(MESSAGE_EDIT_NOTE_SUCCESS, note), false, false,
+                    false, true);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
@@ -17,10 +17,10 @@ public class EditNoteCommand extends Command {
             + " content/updated-note name/name-of-event type/type-of-event";
     public static final String MESSAGE_EXAMPLE = "editNote index/1 content/this is my updated notes name/"
             + "tutorial 1 type/Tutorial";
-    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your "
+    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note indexed %1$s is not found in your "
             + "specified event %2$s!";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
-            + " cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";
+            + " cannot be recognized! Please enter type such as Tutorial, Lab, or Consultation";
     public static final String MESSAGE_EDIT_NOTE_SUCCESS = "Edited note: %1$s";
 
     public static final String TUTORIAL_STRING = "Tutorial";

--- a/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
@@ -13,10 +13,10 @@ import seedu.address.model.event.Note;
 public class EditNoteCommand extends Command {
     public static final String COMMAND_WORD = "editNote";
 
-    public static final String MESSAGE_USAGE = "Edit syntax: editNote -index INDEX (must be a positive integer)"
-            + " -content updated-note -name name-of-event -type type-of-event";
-    public static final String MESSAGE_EXAMPLE = "editNote -index 1 -content this is my updated notes -name "
-            + "tutorial 1 -type Tutorial";
+    public static final String MESSAGE_USAGE = "Edit syntax: editNote index/ INDEX (must be a positive integer)"
+            + " content/ updated-note name/ name-of-event type/ type-of-event";
+    public static final String MESSAGE_EXAMPLE = "editNote index/ 1 content/ this is my updated notes name/ "
+            + "tutorial 1 type/ Tutorial";
     public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your specified event %2$s!";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
             + " cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";

--- a/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
@@ -17,8 +17,8 @@ public class EditNoteCommand extends Command {
             + " content/updated-note name/name-of-event type/type-of-event";
     public static final String MESSAGE_EXAMPLE = "editNote index/1 content/this is my updated notes name/"
             + "tutorial 1 type/Tutorial";
-    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your " +
-            "specified event %2$s!";
+    public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your "
+            + "specified event %2$s!";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
             + " cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";
     public static final String MESSAGE_EDIT_NOTE_SUCCESS = "Edited note: %1$s";

--- a/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
@@ -59,7 +59,7 @@ public class EditNoteCommand extends Command {
             throw new CommandException(String.format(MESSAGE_NOTE_INDEX_NOT_FOUND, targetIndex.getOneBased(),
                     eventName));
         } else {
-            return new CommandResult(String.format(MESSAGE_EDIT_NOTE_SUCCESS, note), false, false,
+            return new CommandResult(String.format(MESSAGE_EDIT_NOTE_SUCCESS, note.getContent()), false, false,
                     false, true);
         }
     }

--- a/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditNoteCommand.java
@@ -13,10 +13,10 @@ import seedu.address.model.event.Note;
 public class EditNoteCommand extends Command {
     public static final String COMMAND_WORD = "editNote";
 
-    public static final String MESSAGE_USAGE = "Edit syntax: editNote index/ INDEX (must be a positive integer)"
-            + " content/ updated-note name/ name-of-event type/ type-of-event";
-    public static final String MESSAGE_EXAMPLE = "editNote index/ 1 content/ this is my updated notes name/ "
-            + "tutorial 1 type/ Tutorial";
+    public static final String MESSAGE_USAGE = "Edit syntax: editNote index/INDEX (must be a positive integer)"
+            + " content/updated-note name/name-of-event type/type-of-event";
+    public static final String MESSAGE_EXAMPLE = "editNote index/1 content/this is my updated notes name/"
+            + "tutorial 1 type/Tutorial";
     public static final String MESSAGE_NOTE_INDEX_NOT_FOUND = "The note index %1$s is not found in your specified event %2$s!";
     public static final String MESSAGE_EVENT_TYPE_NOT_RECOGNIZED = "The event type that you have entered"
             + " cannot be recognized! Please enter command containing Tutorial, Lab, or Consultation";

--- a/src/main/java/seedu/address/logic/parser/AddConsultationParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddConsultationParser.java
@@ -79,6 +79,9 @@ public class AddConsultationParser implements Parser<AddConsultationCommand> {
         }
         if (argMultimap.getValue(PREFIX_NOTE).isPresent()) {
             note = ParserUtil.parseEventNote(argMultimap.getValue(PREFIX_NOTE).get());
+            if (note.length() > Note.LENGTH_LIMIT) {
+                throw new ParseException(String.format("Note is too long! Shrink it to under %1$s", Note.LENGTH_LIMIT));
+            }
             consultation.addNote(new Note(note));
         }
         return new AddConsultationCommand(consultation);

--- a/src/main/java/seedu/address/logic/parser/AddLabParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLabParser.java
@@ -79,6 +79,9 @@ public class AddLabParser implements Parser<AddLabCommand> {
         }
         if (argMultimap.getValue(PREFIX_NOTE).isPresent()) {
             note = ParserUtil.parseEventNote(argMultimap.getValue(PREFIX_NOTE).get());
+            if (note.length() > Note.LENGTH_LIMIT) {
+                throw new ParseException(String.format("Note is too long! Shrink it to under %1$s", Note.LENGTH_LIMIT));
+            }
             lab.addNote(new Note(note));
         }
         return new AddLabCommand(lab);

--- a/src/main/java/seedu/address/logic/parser/AddNoteParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNoteParser.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_CONTENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_EVENT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_EVENT_TYPE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE_EXTERNAL;
 
 import java.util.stream.Stream;
 

--- a/src/main/java/seedu/address/logic/parser/AddNoteParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddNoteParser.java
@@ -27,7 +27,7 @@ public class AddNoteParser implements Parser<AddNoteToEventCommand> {
         requireNonNull(args);
         String newArgs = args.trim().replaceFirst("Note", "");
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(newArgs, PREFIX_NOTE_EXTERNAL, PREFIX_NOTE_CONTENT,
+                ArgumentTokenizer.tokenize(args, PREFIX_NOTE_CONTENT,
                         PREFIX_NOTE_EVENT_TYPE, PREFIX_NOTE_EVENT_NAME);
         if (arePrefixesAbsent(argMultimap, PREFIX_NOTE_CONTENT)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -39,10 +39,13 @@ public class AddNoteParser implements Parser<AddNoteToEventCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddNoteToEventCommand.MESSAGE_USAGE));
         }
-        String name = ParserUtil.parseNoteContent(argMultimap.getValue(PREFIX_NOTE_CONTENT).get());
+        String content = ParserUtil.parseNoteContent(argMultimap.getValue(PREFIX_NOTE_CONTENT).get());
         String eventName = argMultimap.getValue(PREFIX_NOTE_EVENT_NAME).get();
         String eventType = argMultimap.getValue(PREFIX_NOTE_EVENT_TYPE).get();
-        Note note = new Note(name);
+        if (content.length() > Note.LENGTH_LIMIT) {
+            throw new ParseException(String.format("Note is too long! Shrink it to under %1$s", Note.LENGTH_LIMIT));
+        }
+        Note note = new Note(content);
         return new AddNoteToEventCommand(note, eventName, eventType);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddTutorialParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddTutorialParser.java
@@ -76,6 +76,9 @@ public class AddTutorialParser implements Parser<AddTutorialCommand> {
         }
         if (argMultimap.getValue(PREFIX_NOTE).isPresent()) {
             note = ParserUtil.parseEventNote(argMultimap.getValue(PREFIX_NOTE).get());
+            if (note.length() > Note.LENGTH_LIMIT) {
+                throw new ParseException(String.format("Note is too long! Shrink it to under %1$s", Note.LENGTH_LIMIT));
+            }
             tutorial.addNote(new Note(note));
         }
         return new AddTutorialCommand(tutorial);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -27,8 +27,8 @@ public class CliSyntax {
 
     // Add note directly instead of depending on events
     public static final Prefix PREFIX_NOTE_EXTERNAL = new Prefix("Note/");
-    public static final Prefix PREFIX_NOTE_CONTENT = new Prefix("-content ");
-    public static final Prefix PREFIX_NOTE_EVENT_TYPE = new Prefix("-type ");
-    public static final Prefix PREFIX_NOTE_EVENT_NAME = new Prefix("-name ");
-    public static final Prefix PREFIX_NOTE_INDEX = new Prefix("-index ");
+    public static final Prefix PREFIX_NOTE_CONTENT = new Prefix("content/");
+    public static final Prefix PREFIX_NOTE_EVENT_TYPE = new Prefix("type/");
+    public static final Prefix PREFIX_NOTE_EVENT_NAME = new Prefix("name/");
+    public static final Prefix PREFIX_NOTE_INDEX = new Prefix("index/");
 }

--- a/src/main/java/seedu/address/logic/parser/EditNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditNoteCommandParser.java
@@ -37,6 +37,9 @@ public class EditNoteCommandParser implements Parser<EditNoteCommand> {
                     + EditNoteCommand.MESSAGE_EXAMPLE);
         }
         String content = argMultimap.getValue(PREFIX_NOTE_CONTENT).get();
+        if (content.length() > Note.LENGTH_LIMIT) {
+            throw new ParseException(String.format("Note is too long! Shrink it to under %1$s", Note.LENGTH_LIMIT));
+        }
         Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_NOTE_INDEX).get());
         String eventName = argMultimap.getValue(PREFIX_NOTE_EVENT_NAME).get();
         String eventType = argMultimap.getValue(PREFIX_NOTE_EVENT_TYPE).get();

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -409,7 +409,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean removeNoteFromTutorial(Index index, String nameOfEvent) {
         for (Tutorial tut : tutorials) {
             if (tut.hasMatchByName(nameOfEvent)) {
-                return tut.removeNote(tut.getNoteList().get(index.getZeroBased()));
+                try {
+                    return tut.removeNote(index.getZeroBased());
+                } catch (IndexOutOfBoundsException e) {
+                    return false;
+                }
             }
         }
         return false;
@@ -423,7 +427,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean removeNoteFromLab(Index index, String nameOfEvent) {
         for (Lab lab : labs) {
             if (lab.hasMatchByName(nameOfEvent)) {
-                return lab.removeNote(lab.getNoteList().get(index.getZeroBased()));
+                try {
+                    return lab.removeNote(index.getZeroBased());
+                } catch (IndexOutOfBoundsException e) {
+                    return false;
+                }
             }
         }
         return false;
@@ -437,7 +445,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean removeNoteFromConsultation(Index index, String nameOfEvent) {
         for (Consultation consultation : consultations) {
             if (consultation.hasMatchByName(nameOfEvent)) {
-                return consultation.removeNote(consultation.getNoteList().get(index.getZeroBased()));
+                try {
+                    return consultation.removeNote(index.getZeroBased());
+                } catch (IndexOutOfBoundsException e) {
+                    return false;
+                }
             }
         }
         return false;
@@ -453,6 +465,7 @@ public class AddressBook implements ReadOnlyAddressBook {
             if (consultation.hasMatchByName(nameOfEvent)) {
                 return consultation.setNote(note, index);
             }
+
         }
         return false;
     }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -400,12 +400,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @param index Index of note to remove
      * @param nameOfEvent Event name
      */
-    public void removeNoteFromTutorial(Index index, String nameOfEvent) {
+    public boolean removeNoteFromTutorial(Index index, String nameOfEvent) {
         for (Tutorial tut : tutorials) {
             if (tut.hasMatchByName(nameOfEvent)) {
-                tut.removeNote(tut.getNoteList().get(index.getZeroBased()));
+                return tut.removeNote(tut.getNoteList().get(index.getZeroBased()));
             }
         }
+        return false;
     }
 
     /**
@@ -413,12 +414,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @param index Index of note to remove
      * @param nameOfEvent Event name
      */
-    public void removeNoteFromLab(Index index, String nameOfEvent) {
+    public boolean removeNoteFromLab(Index index, String nameOfEvent) {
         for (Lab lab : labs) {
             if (lab.hasMatchByName(nameOfEvent)) {
-                lab.removeNote(lab.getNoteList().get(index.getZeroBased()));
+                return lab.removeNote(lab.getNoteList().get(index.getZeroBased()));
             }
         }
+        return false;
     }
 
     /**
@@ -426,12 +428,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @param index Index of note to remove
      * @param nameOfEvent Event name
      */
-    public void removeNoteFromConsultation(Index index, String nameOfEvent) {
+    public boolean removeNoteFromConsultation(Index index, String nameOfEvent) {
         for (Consultation consultation : consultations) {
             if (consultation.hasMatchByName(nameOfEvent)) {
-                consultation.removeNote(consultation.getNoteList().get(index.getZeroBased()));
+                return consultation.removeNote(consultation.getNoteList().get(index.getZeroBased()));
             }
         }
+        return false;
     }
 
     /**
@@ -439,12 +442,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @param index Index of note to edit
      * @param nameOfEvent Event name
      */
-    public void editNoteFromConsultation(Index index, Note note, String nameOfEvent) {
+    public boolean editNoteFromConsultation(Index index, Note note, String nameOfEvent) {
         for (Consultation consultation : consultations) {
             if (consultation.hasMatchByName(nameOfEvent)) {
-                consultation.setNote(note, index);
+                return consultation.setNote(note, index);
             }
         }
+        return false;
     }
 
     /**
@@ -452,12 +456,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @param index Index of note to edit
      * @param nameOfEvent Event name
      */
-    public void editNoteFromLab(Index index, Note note, String nameOfEvent) {
+    public boolean editNoteFromLab(Index index, Note note, String nameOfEvent) {
         for (Lab lab : labs) {
             if (lab.hasMatchByName(nameOfEvent)) {
-                lab.setNote(note, index);
+                return lab.setNote(note, index);
             }
         }
+        return false;
     }
 
     /**
@@ -465,12 +470,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      * @param index Index of note to edit
      * @param nameOfEvent Event name
      */
-    public void editNoteFromTutorial(Index index, Note note, String nameOfEvent) {
+    public boolean editNoteFromTutorial(Index index, Note note, String nameOfEvent) {
         for (Tutorial tutorial : tutorials) {
             if (tutorial.hasMatchByName(nameOfEvent)) {
-                tutorial.setNote(note, index);
+                return tutorial.setNote(note, index);
             }
         }
+        return false;
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -354,45 +354,51 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Adds note to address book tutorial note list
      * @param note The note to add.
      */
-    public void addNoteToTutorial(Note note, String nameOfEvent) {
+    public boolean addNoteToTutorial(Note note, String nameOfEvent) {
         if (!(tutorials.containsEventName(nameOfEvent))) {
-            return;
+            return false;
         }
         for (Tutorial tutorial : tutorials) {
             if (tutorial.hasMatchByName(nameOfEvent)) {
                 tutorial.addNote(note);
+                return true;
             }
         }
+        return false;
     }
 
     /**
      * Adds note to address book lab note list
      * @param note The note to add.
      */
-    public void addNoteToLab(Note note, String nameOfEvent) {
+    public boolean addNoteToLab(Note note, String nameOfEvent) {
         if (!(labs.containsEventName(nameOfEvent))) {
-            return;
+            return false;
         }
         for (Lab lab : labs) {
             if (lab.hasMatchByName(nameOfEvent)) {
                 lab.addNote(note);
+                return true;
             }
         }
+        return false;
     }
 
     /**
      * Adds note to address book consultation note list
      * @param note The note to add.
      */
-    public void addNoteToConsultation(Note note, String nameOfEvent) {
+    public boolean addNoteToConsultation(Note note, String nameOfEvent) {
         if (!(consultations.containsEventName(nameOfEvent))) {
-            return;
+            return false;
         }
         for (Consultation consultation : consultations) {
             if (consultation.hasMatchByName(nameOfEvent)) {
                 consultation.addNote(note);
+                return true;
             }
         }
+        return false;
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -243,19 +243,19 @@ public interface Model {
      * Append notes to an existing tutorial note list
      * @param note The note to add
      */
-    void addNoteToTutorial(Note note, String nameOfEvent);
+    boolean addNoteToTutorial(Note note, String nameOfEvent);
 
     /**
      * Append notes to an existing lab note list
      * @param note The note to add
      */
-    void addNoteToLab(Note note, String nameOfEvent);
+    boolean addNoteToLab(Note note, String nameOfEvent);
 
     /**
      * Append notes to an existing consultation note list
      * @param note The note to add
      */
-    void addNoteToConsultation(Note note, String nameOfEvent);
+    boolean addNoteToConsultation(Note note, String nameOfEvent);
 
     void updateSortTutorialPersonList(String metric, boolean isIncreasing);
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -231,13 +231,13 @@ public interface Model {
      */
     void updateFilteredConsultationList(Predicate<Consultation> predicate);
 
-    void editNoteFromTutorial(Index index, Note note, String nameOfEvent);
-    void editNoteFromLab(Index index, Note note, String nameOfEvent);
-    void editNoteFromConsultation(Index index, Note note, String nameOfEvent);
+    boolean editNoteFromTutorial(Index index, Note note, String nameOfEvent);
+    boolean editNoteFromLab(Index index, Note note, String nameOfEvent);
+    boolean editNoteFromConsultation(Index index, Note note, String nameOfEvent);
 
-    void removeNoteFromTutorial(Index index, String nameOfEvent);
-    void removeNoteFromLab(Index index, String nameOfEvent);
-    void removeNoteFromConsultation(Index index, String nameOfEvent);
+    boolean removeNoteFromTutorial(Index index, String nameOfEvent);
+    boolean removeNoteFromLab(Index index, String nameOfEvent);
+    boolean removeNoteFromConsultation(Index index, String nameOfEvent);
 
     /**
      * Append notes to an existing tutorial note list

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -226,21 +226,21 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void addNoteToTutorial(Note note, String nameOfEvent) {
+    public boolean addNoteToTutorial(Note note, String nameOfEvent) {
         requireNonNull(note);
-        addressBook.addNoteToTutorial(note, nameOfEvent);
+        return addressBook.addNoteToTutorial(note, nameOfEvent);
     }
 
     @Override
-    public void addNoteToLab(Note note, String nameOfEvent) {
+    public boolean addNoteToLab(Note note, String nameOfEvent) {
         requireNonNull(note);
-        addressBook.addNoteToLab(note, nameOfEvent);
+        return addressBook.addNoteToLab(note, nameOfEvent);
     }
 
     @Override
-    public void addNoteToConsultation(Note note, String nameOfEvent) {
+    public boolean addNoteToConsultation(Note note, String nameOfEvent) {
         requireNonNull(note);
-        addressBook.addNoteToConsultation(note, nameOfEvent);
+        return addressBook.addNoteToConsultation(note, nameOfEvent);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -244,40 +244,40 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void removeNoteFromTutorial(Index index, String nameOfEvent) {
+    public boolean removeNoteFromTutorial(Index index, String nameOfEvent) {
         requireNonNull(index);
-        addressBook.removeNoteFromTutorial(index, nameOfEvent);
+        return addressBook.removeNoteFromTutorial(index, nameOfEvent);
     }
 
     @Override
-    public void removeNoteFromLab(Index index, String nameOfEvent) {
+    public boolean removeNoteFromLab(Index index, String nameOfEvent) {
         requireNonNull(index);
-        addressBook.removeNoteFromLab(index, nameOfEvent);
+        return addressBook.removeNoteFromLab(index, nameOfEvent);
     }
 
     @Override
-    public void removeNoteFromConsultation(Index index, String nameOfEvent) {
+    public boolean removeNoteFromConsultation(Index index, String nameOfEvent) {
         requireNonNull(index);
-        addressBook.removeNoteFromConsultation(index, nameOfEvent);
+        return addressBook.removeNoteFromConsultation(index, nameOfEvent);
     }
 
     @Override
-    public void editNoteFromTutorial(Index index, Note note, String nameOfEvent) {
+    public boolean editNoteFromTutorial(Index index, Note note, String nameOfEvent) {
         requireNonNull(index);
         requireNonNull(note);
-        addressBook.editNoteFromTutorial(index, note, nameOfEvent);
+        return addressBook.editNoteFromTutorial(index, note, nameOfEvent);
     }
     @Override
-    public void editNoteFromLab(Index index, Note note, String nameOfEvent) {
+    public boolean editNoteFromLab(Index index, Note note, String nameOfEvent) {
         requireNonNull(index);
         requireNonNull(note);
-        addressBook.editNoteFromLab(index, note, nameOfEvent);
+        return addressBook.editNoteFromLab(index, note, nameOfEvent);
     }
     @Override
-    public void editNoteFromConsultation(Index index, Note note, String nameOfEvent) {
+    public boolean editNoteFromConsultation(Index index, Note note, String nameOfEvent) {
         requireNonNull(index);
         requireNonNull(note);
-        addressBook.editNoteFromConsultation(index, note, nameOfEvent);
+        return addressBook.editNoteFromConsultation(index, note, nameOfEvent);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/event/Consultation.java
+++ b/src/main/java/seedu/address/model/event/Consultation.java
@@ -132,8 +132,8 @@ public class Consultation extends Event {
         return super.countNotes();
     }
 
-    public void removeNote(Note note) {
-        super.removeNote(note);
+    public boolean removeNote(Note note) {
+        return super.removeNote(note);
     }
 
     /**

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -282,6 +282,11 @@ public abstract class Event {
         notes.add(note);
     }
 
+    /**
+     * Removes from note list
+     * @param note A note object
+     * @return Remove outcome
+     */
     public boolean removeNote(Note note) {
         try {
             return notes.remove(note);
@@ -290,6 +295,11 @@ public abstract class Event {
         }
     }
 
+    /**
+     * Removes a note from note list by index
+     * @param index The index of note to remove
+     * @return Removal outcome
+     */
     public boolean removeNote(int index) {
         try {
             return notes.remove(index);

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -257,8 +257,13 @@ public abstract class Event {
         return notes.contains(note);
     }
 
-    public void setNote(Note note, Index index) {
-        notes.replace(note, index.getZeroBased());
+    public boolean setNote(Note note, Index index) {
+        try {
+            notes.replace(note, index.getZeroBased());
+            return true;
+        } catch (IndexOutOfBoundsException e) {
+            return false;
+        }
     }
 
     public List<Note> getNotes() {
@@ -277,8 +282,8 @@ public abstract class Event {
         notes.add(note);
     }
 
-    public void removeNote(Note note) {
-        notes.remove(note);
+    public boolean removeNote(Note note) {
+        return notes.remove(note);
     }
 
     /**

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -129,7 +129,7 @@ public abstract class Event {
     }
 
     public boolean hasMatchByName(String name) {
-        return this.name.equals(name);
+        return this.name.equalsIgnoreCase(name);
     }
 
     /* *************************************************************************

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -283,7 +283,19 @@ public abstract class Event {
     }
 
     public boolean removeNote(Note note) {
-        return notes.remove(note);
+        try {
+            return notes.remove(note);
+        } catch (NullPointerException e) {
+            return false;
+        }
+    }
+
+    public boolean removeNote(int index) {
+        try {
+            return notes.remove(index);
+        } catch (IndexOutOfBoundsException e) {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/event/Lab.java
+++ b/src/main/java/seedu/address/model/event/Lab.java
@@ -150,8 +150,8 @@ public class Lab extends Event {
         return super.countNotes();
     }
 
-    public void removeNote(Note note) {
-        super.removeNote(note);
+    public boolean removeNote(Note note) {
+        return super.removeNote(note);
     }
 
     /**

--- a/src/main/java/seedu/address/model/event/Lab.java
+++ b/src/main/java/seedu/address/model/event/Lab.java
@@ -154,6 +154,7 @@ public class Lab extends Event {
         return super.removeNote(note);
     }
 
+
     /**
      * Checks for the same lab by comparing name and date
      *

--- a/src/main/java/seedu/address/model/event/Note.java
+++ b/src/main/java/seedu/address/model/event/Note.java
@@ -1,5 +1,7 @@
 package seedu.address.model.event;
 
+import seedu.address.model.event.exceptions.NoteLengthException;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -11,16 +13,16 @@ import java.util.regex.Pattern;
 public class Note {
 
     public static final String EMPTY_CONTENT = "This note is empty";
-    protected static final int LENGTH_LIMIT = 200;
+    public static final int LENGTH_LIMIT = 200;
     private static final String PATTERN = "@[a-z]+";
     private String content;
-    private List<String> names = new ArrayList<>(20); // referenced up to 20 people in the notes
+    private final List<String> names = new ArrayList<>(20); // referenced up to 20 people in the notes
 
     /**
-     * Initates the note object with actual content and parsed referees
+     * Initiates the note object with actual content and parsed referees
      * @param content {@code String} object that represents the note contents
      */
-    public Note(String content) {
+    public Note(String content) throws NoteLengthException {
         this.content = validateContent(content);
         decomposePersonNames(content);
     }
@@ -37,8 +39,8 @@ public class Note {
             Pattern pattern = Pattern.compile(PATTERN, Pattern.CASE_INSENSITIVE);
             Matcher matcher = pattern.matcher(note);
             while (matcher.find()) {
-                String name = matcher.group().toString();
-                name = name.substring(1, name.length()); // get rid of @ char
+                String name = matcher.group();
+                name = name.substring(1); // get rid of @ char
                 this.names.add(name);
             }
         } catch (Exception e) { // TODO: better exception handling
@@ -46,12 +48,12 @@ public class Note {
         }
     }
 
-    private String validateContent(String note) {
+    private String validateContent(String note) throws NoteLengthException {
         // utf-8 check left to ui input handler
         if (note.isEmpty()) {
             note = EMPTY_CONTENT;
         } else if (note.length() >= LENGTH_LIMIT) {
-            note = note.substring(0, LENGTH_LIMIT);
+            throw new NoteLengthException(LENGTH_LIMIT, note.length());
         }
         return note;
     }

--- a/src/main/java/seedu/address/model/event/Note.java
+++ b/src/main/java/seedu/address/model/event/Note.java
@@ -1,11 +1,12 @@
 package seedu.address.model.event;
 
-import seedu.address.model.event.exceptions.NoteLengthException;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import seedu.address.model.event.exceptions.NoteLengthException;
+
 
 /**
  * Allows the TA to create notes in an event

--- a/src/main/java/seedu/address/model/event/NoteList.java
+++ b/src/main/java/seedu/address/model/event/NoteList.java
@@ -86,7 +86,7 @@ public class NoteList {
      * Removes the specified note
      * @param note The note to remove from the list
      */
-    public boolean remove(Note note) {
+    public boolean remove(Note note) throws NullPointerException {
         requireNonNull(note);
         return getNotes().remove(note);
     }
@@ -95,9 +95,10 @@ public class NoteList {
      * Removes the indexed note
      * @param index Integer for index
      */
-    public Note remove(int index) throws IndexOutOfBoundsException {
+    public boolean remove(int index) throws IndexOutOfBoundsException {
         requireNonNull(index);
-        return getNotes().remove(index);
+        getNotes().remove(index);
+        return true;
     }
 
     /**

--- a/src/main/java/seedu/address/model/event/Tutorial.java
+++ b/src/main/java/seedu/address/model/event/Tutorial.java
@@ -150,8 +150,8 @@ public class Tutorial extends Event {
         return super.countNotes();
     }
 
-    public void removeNote(Note note) {
-        super.removeNote(note);
+    public boolean removeNote(Note note) {
+        return super.removeNote(note);
     }
 
     /**

--- a/src/main/java/seedu/address/model/event/exceptions/NoteLengthException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/NoteLengthException.java
@@ -6,5 +6,5 @@ package seedu.address.model.event.exceptions;
 public class NoteLengthException extends RuntimeException {
      public NoteLengthException(int limit, int length) {
         super(String.format("You have longer than limit: %1$s note length: %2$s!", limit, length));
-    }
+     }
 }

--- a/src/main/java/seedu/address/model/event/exceptions/NoteLengthException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/NoteLengthException.java
@@ -4,7 +4,7 @@ package seedu.address.model.event.exceptions;
  * The added note has illegal length
  */
 public class NoteLengthException extends RuntimeException {
-     public NoteLengthException(int limit, int length) {
+    public NoteLengthException(int limit, int length) {
         super(String.format("You have longer than limit: %1$s note length: %2$s!", limit, length));
-     }
+    }
 }

--- a/src/main/java/seedu/address/model/event/exceptions/NoteLengthException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/NoteLengthException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.event.exceptions;
+
+/**
+ * The added note has illegal length
+ */
+public class NoteLengthException extends RuntimeException {
+     public NoteLengthException(int limit, int length) {
+        super(String.format("You have longer than limit: %1$s note length: %2$s!", limit, length));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -280,17 +280,17 @@ public class AddCommandTest {
         }
 
         @Override
-        public void addNoteToTutorial(Note note, String nameOfEvent) {
+        public boolean addNoteToTutorial(Note note, String nameOfEvent) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void addNoteToLab(Note note, String nameOfEvent) {
+        public boolean addNoteToLab(Note note, String nameOfEvent) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void addNoteToConsultation(Note note, String nameOfEvent) {
+        public boolean addNoteToConsultation(Note note, String nameOfEvent) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -295,30 +295,30 @@ public class AddCommandTest {
         }
 
         @Override
-        public void removeNoteFromConsultation(Index index, String nameOfEvent) {
+        public boolean removeNoteFromConsultation(Index index, String nameOfEvent) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void removeNoteFromLab(Index index, String nameOfEvent) {
+        public boolean removeNoteFromLab(Index index, String nameOfEvent) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void removeNoteFromTutorial(Index index, String nameOfEvent) {
+        public boolean removeNoteFromTutorial(Index index, String nameOfEvent) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void editNoteFromTutorial(Index index, Note note, String nameOfEvent) {
+        public boolean editNoteFromTutorial(Index index, Note note, String nameOfEvent) {
             throw new AssertionError("This method should not be called.");
         }
         @Override
-        public void editNoteFromLab(Index index, Note note, String nameOfEvent) {
+        public boolean editNoteFromLab(Index index, Note note, String nameOfEvent) {
             throw new AssertionError("This method should not be called.");
         }
         @Override
-        public void editNoteFromConsultation(Index index, Note note, String nameOfEvent) {
+        public boolean editNoteFromConsultation(Index index, Note note, String nameOfEvent) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
* Fix case-sensitive requirements of "Tutorial" to any string containing the string "tutorial";
* Add checker for whether note index exists in the specified event, and make customized error message; 
* Modify add/edit/delete command from '-name' to 'name/[NAME]' for better consistency.
* Limit note to 200 char and flag error if exceeding.
* Edit UG accordingly.

Solve: #238 , #239